### PR TITLE
Fixing two_sample default noise_model

### DIFF
--- a/diffxpy/testing/tests.py
+++ b/diffxpy/testing/tests.py
@@ -912,7 +912,7 @@ def two_sample(
         test: str = "t-test",
         gene_names: Union[np.ndarray, list] = None,
         sample_description: pd.DataFrame = None,
-        noise_model: str = None,
+        noise_model: str = "nb",
         size_factors: np.ndarray = None,
         batch_size: Union[None, int, Tuple[int, int]] = None,
         backend: str = "numpy",


### PR DESCRIPTION
default noise_model in the two_sample helper function now matches the docstring and other testing methods