### PR TITLE
pin sparse to 0.9.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,4 +12,4 @@ sphinx-autodoc-typehints
 sphinx_rtd_theme
 jinja2
 docutils
-
+sparse==0.9.1


### PR DESCRIPTION
fixes #194

Not quite sure where sparse comes from, but I think that a pin in the final package should work either way.